### PR TITLE
Fix bug: resultserver always bans to receive all.stap from guest OS o…

### DIFF
--- a/cuckoo/core/resultserver.py
+++ b/cuckoo/core/resultserver.py
@@ -46,7 +46,7 @@ def netlog_sanitize_fname(path):
     """Validate agent-provided path for result files"""
     path = path.replace("\\", "/")
     dir_part, name = os.path.split(path)
-    if dir_part not in RESULT_UPLOADABLE:
+    if dir_part not in RESULT_DIRECTORIES:
         raise CuckooOperationalError("Netlog client requested banned path: %r"
                                      % path)
     if any(c in BANNED_PATH_CHARS for c in name):


### PR DESCRIPTION
…f Linux.

resultserver.py always raises "Netlog client requested banned path: logs/all.stap"
because the "dir_part", logs, of "logs/all.stap" hits the code "if dir_part not in RESULT_UPLOADABLE"
where "logs" is not included in "RESULT_UPLOADABLE".

Thanks for contributing! But first: did you read our community guidelines?
https://cuckoo.sh/docs/introduction/community.html

##### What I have added/changed is:

##### The goal of my change is:

##### What I have tested about my change is:
